### PR TITLE
BAMParser Extensibility Enhancements

### DIFF
--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -19,4 +19,6 @@
   <repository path="../Source/Tools/TestDataFilter/packages.config" />
   <repository path="../Source/Tools/Tools.VennToNodeXL/packages.config" />
   <repository path="../Source/Tools/VennTool/packages.config" />
+  <repository path="..\Source\Tests\Bio.Tests\packages.config" />
+  <repository path="..\Source\Tests\Bio.TestUtils\packages.config" />
 </repositories>


### PR DESCRIPTION
Created a generic version of the BAMParser class that will allow for
easier extension of the class by developers using the .NET Bio library.
Also, to maintain compatibility with existing code, there is also a
non-generic version of the BAMParser class that inherits from the
generic version of the class with the template parameter set to
SAMAlignedSequence.

If this change is except, I would also like to suggest that we allow the BAMParser class accept a factory method as a constructor parameter. Such a feature would further improve the extensibility of the class by inverting the control of object creation.
