### PR TITLE
Fix NeedlmanWunschAligner

### DIFF
--- a/src/Source/Framework/Bio.Core/Algorithms/Alignment/NeedlemanWunschAligner.cs
+++ b/src/Source/Framework/Bio.Core/Algorithms/Alignment/NeedlemanWunschAligner.cs
@@ -158,6 +158,9 @@ namespace Bio.Algorithms.Alignment
             {
                 //can't move horizontally at this stage, set to value 
                 //where gap open is destined to be better.
+                sbyte[] traceback = new sbyte[Cols];
+                traceback [0] = SourceDirection.Up;
+                Traceback [i] = traceback;
                 hgapCost[i * gapStride] = 2*GapOpenCost*i;
                 v_Gap_Length[i * gapStride] = i;
                 int initialScore = (i - 1) * GapExtensionCost + GapOpenCost;
@@ -182,10 +185,9 @@ namespace Bio.Algorithms.Alignment
             for (int i = 1; i < Rows; i++)
             {
                 // Create the next TB row
-                sbyte[] traceback = new sbyte[Cols];
+                sbyte[] traceback = Traceback[i];
                 if (i > 1)
                 {
-                    traceback[0] = SourceDirection.Up;
                     // Move current row to last row, Array.Copy(scoreRow, scoreLastRow, Cols);
                     var tmp = scoreLastRow;
                     scoreLastRow = scoreRow;
@@ -252,9 +254,6 @@ namespace Bio.Algorithms.Alignment
                         traceback[j] = SourceDirection.Up;
                     }
                 }
-
-                // Save off the TB row
-                Traceback[i] = traceback;
 
                 if (IncludeScoreTable)
                 {

--- a/src/Source/Tests/Bio.Tests/Algorithms/Alignment/NeedlemanWunschP2TestCases.cs
+++ b/src/Source/Tests/Bio.Tests/Algorithms/Alignment/NeedlemanWunschP2TestCases.cs
@@ -1285,6 +1285,46 @@ namespace Bio.Tests.Algorithms.Alignment
                 AlignmentType.Align);
         }
 
+
+        /// <summary>
+        /// Validate that sequences with gaps on the ends are handled appropriately 
+        /// by both the simple and affine aligners.
+        /// 
+        /// This test exists because the aligner did not tack on the ends of query sequences before.
+        ///     Validation : Aligned sequence and score.
+        /// </summary>
+        [Test]
+        [Category("Priority2")]
+        public void ValidateNeedlemanWunschAlignTwoSequencesWithEndGaps()
+        {
+            var exp_ref = "-ATTGTATGGCCAACAA-";
+            var refseq= new Sequence (DnaAlphabet.Instance, exp_ref.Replace("-", ""));
+            var query = new Sequence (DnaAlphabet.Instance, "CATTGTATGGCCAACAAG");
+            NeedlemanWunschAligner alner = new NeedlemanWunschAligner();
+
+            var res_affine = alner.Align (refseq, query).First().PairwiseAlignedSequences.First();
+            Assert.AreEqual (query.Count, res_affine.FirstSequence.Count);
+            Assert.AreEqual (query.Count, res_affine.SecondSequence.Count);
+            Assert.AreEqual (exp_ref, res_affine.FirstSequence.ConvertToString ());
+
+            var res_simple = alner.AlignSimple (refseq, query).First ().PairwiseAlignedSequences.First ();
+            Assert.AreEqual (query.Count, res_simple.FirstSequence.Count);
+            Assert.AreEqual (query.Count, res_simple.SecondSequence.Count);
+            Assert.AreEqual (exp_ref, res_simple.FirstSequence.ConvertToString ());
+
+            // now to flip sequence 1 and 2, try it again.
+            res_affine = alner.Align (query, refseq).First().PairwiseAlignedSequences.First();
+            Assert.AreEqual (query.Count, res_affine.FirstSequence.Count);
+            Assert.AreEqual (query.Count, res_affine.SecondSequence.Count);
+            Assert.AreEqual (exp_ref, res_affine.SecondSequence.ConvertToString ());
+
+            res_simple = alner.AlignSimple (query, refseq).First ().PairwiseAlignedSequences.First ();
+            Assert.AreEqual (query.Count, res_simple.FirstSequence.Count);
+            Assert.AreEqual (query.Count, res_simple.SecondSequence.Count);
+            Assert.AreEqual (exp_ref, res_simple.SecondSequence.ConvertToString ());
+
+                
+        }
         #endregion
 
         #region Helper Methods

--- a/src/Source/Tests/Bio.Tests/Algorithms/MUMmer/MUMmerAlignerTests.cs
+++ b/src/Source/Tests/Bio.Tests/Algorithms/MUMmer/MUMmerAlignerTests.cs
@@ -201,11 +201,11 @@ namespace Bio.Tests.Algorithms.MUMmer
             IPairwiseSequenceAlignment align = new PairwiseSequenceAlignment();
             align.PairwiseAlignedSequences.Add(new PairwiseAlignedSequence
             {
-                FirstSequence = new Sequence(Alphabets.RNA,  "AUGCUUUUCCCCCCC"),
-                SecondSequence = new Sequence(Alphabets.RNA, "AUA-UUUUGG-----"),
-                Consensus = new Sequence(AmbiguousRnaAlphabet.Instance, "AURCUUUUSSCCCCC"),
+                FirstSequence = new Sequence(Alphabets.RNA,  "-AUGCUUUUCCCCCCC"),
+                SecondSequence = new Sequence(Alphabets.RNA, "UAUA-UUUUGG-----"),
+                Consensus = new Sequence(AmbiguousRnaAlphabet.Instance, "UAURCUUUUSSCCCCC"),
                 Score = -14,
-                FirstOffset = 0,
+                FirstOffset = 1,
                 SecondOffset = 0
             });
             expectedOutput.Add(align);


### PR DESCRIPTION
The aligner was not handling gaps at the end appropriately in the
affine case, as it would neglect to add a leading insert.  This in turn
goofed up the MUMAligner.