### PR TITLE
Validate Alignment Sequences Aren't Too Large

### DIFF
--- a/src/Source/Framework/Bio.Core/Algorithms/Alignment/NeedlemanWunschAligner.cs
+++ b/src/Source/Framework/Bio.Core/Algorithms/Alignment/NeedlemanWunschAligner.cs
@@ -192,8 +192,14 @@ namespace Bio.Algorithms.Alignment
              * which allows us to transition into and out of the gap matrices in one
              * step, rather than following paths through them.
              */
-            h_Gap_Length = new int[(Rows + 1) * gapStride];
-            v_Gap_Length = new int[(Rows + 1) * gapStride];
+            var matrixSize = checked((Rows + 1) * gapStride);
+            try {
+                h_Gap_Length = new int[matrixSize];
+                v_Gap_Length = new int[matrixSize];
+            }
+            catch(OutOfMemoryException oom) {
+                throw new OutOfMemoryException (GenerateOOMErrorMessageWhenAllocatingGapTracebacks (), oom);
+            }
 
             /* As we progress through, we only need to know about 
              * the current row and the previous row for the recursions,

--- a/src/Source/Framework/Bio.Core/Algorithms/Alignment/SmithWatermanAligner.cs
+++ b/src/Source/Framework/Bio.Core/Algorithms/Alignment/SmithWatermanAligner.cs
@@ -141,10 +141,17 @@ namespace Bio.Algorithms.Alignment
 
             // Horizontal and vertical gap counts.
             int gapStride = Cols + 1;
-            h_Gap_Length = new int[(Rows + 1) * gapStride];
-            v_Gap_Length = new int[(Rows + 1) * gapStride];
-            int[] hgapCost = new int[(Rows + 1) * gapStride];
-            int[] vgapCost = new int[(Rows + 1) * gapStride];
+            var matrixSize = checked((Rows + 1) * gapStride);
+            int[] hgapCost, vgapCost;
+            try {
+                h_Gap_Length = new int[matrixSize];
+                v_Gap_Length = new int[matrixSize];
+                hgapCost = new int[matrixSize];
+                vgapCost = new int[matrixSize];
+            }
+            catch(OutOfMemoryException oom) {
+                throw new OutOfMemoryException (GenerateOOMErrorMessageWhenAllocatingGapTracebacks (), oom);
+            }
 
             // Initialize the gap extension cost matrices.
             for (int i = 1; i < Rows; i++)

--- a/src/Source/Tests/Bio.Tests/Algorithms/Alignment/NeedlemanWunschP2TestCases.cs
+++ b/src/Source/Tests/Bio.Tests/Algorithms/Alignment/NeedlemanWunschP2TestCases.cs
@@ -105,6 +105,28 @@ namespace Bio.Tests.Algorithms.Alignment
 
         #region Test Cases
 
+
+        /// <summary>
+        /// Validate that if we try to do an alignment with sequences that are too large
+        /// for a global M x N matrix allocation, we throw an exception. 
+        /// </summary>
+        [Test]
+        [Category("NeedlemanWunschAligner")]
+        public void NeedlemanWunschThrowsExceptionWhenTooLarge()
+        {
+            // What size squared is too large?
+            int seq_size = (int)Math.Sqrt ((double)Int32.MaxValue) + 5;
+            byte[] seq = new byte[seq_size];
+            // Now let's generate sequences of those size
+            for (int i = 0; i < seq.Length; i++) {
+                seq [i] = (byte)'A';
+            }
+            var seq1 = new Sequence (DnaAlphabet.Instance, seq, false);
+            var na = new NeedlemanWunschAligner ();
+            Assert.Throws(typeof(ArgumentOutOfRangeException),
+                () => na.Align(seq1, seq1));
+        }
+
         /// <summary>
         ///     Pass a Valid Sequence(Lower case) with valid GapPenalty, Similarity Matrix
         ///     which is in a text file using the method Align(sequence1, sequence2)

--- a/src/Source/Tests/Bio.Tests/Algorithms/Alignment/SmithWatermanP2TestCases.cs
+++ b/src/Source/Tests/Bio.Tests/Algorithms/Alignment/SmithWatermanP2TestCases.cs
@@ -124,7 +124,26 @@ namespace Bio.Tests.Algorithms.Alignment
                 AlignParameters.AlignTwo);
         }
 
-
+        /// <summary>
+        /// Validate that if we try to do an alignment with sequences that are too large
+        /// for a global M x N matrix allocation, we throw an exception. 
+        /// </summary>
+        [Test]
+        [Category("Priority2")]
+        public void SmithWatermanThrowsExceptionWhenTooLarge()
+        {
+            // What size squared is too large?
+            int seq_size = (int)Math.Sqrt ((double)Int32.MaxValue) + 5;
+            byte[] seq = new byte[seq_size];
+            // Now let's generate sequences of those size
+            for (int i = 0; i < seq.Length; i++) {
+                seq [i] = (byte)'A';
+            }
+            var seq1 = new Sequence (DnaAlphabet.Instance, seq, false);
+            var na = new SmithWatermanAligner ();
+            Assert.Throws(typeof(ArgumentOutOfRangeException),
+                () => na.Align(seq1, seq1));
+        }
         [Test]
         [Category("Priority2")]
         public void SmithWatermanGotohAlignSequenceWithMultiplePossibleIndelPositions()


### PR DESCRIPTION
No one should try to align sequences of size M and N where M x N >
Int32.MaxValue.  However, it could happen and it leads to overflows and
strange message.  This commit:

* Validates M x N < Int32.MaxValue
* Throws exception with message if not.
* Verifies this behavior with tests.