### PR TITLE
Allow Redundant Paths to Consider Indels

### DIFF
--- a/src/Source/Add-in/Bio.Padena/PathWithOrientation.cs
+++ b/src/Source/Add-in/Bio.Padena/PathWithOrientation.cs
@@ -8,12 +8,17 @@ namespace Bio.Algorithms.Assembly.Padena
     /// Structure that stores list of nodes in path, 
     /// along with path orientation.
     /// </summary>
-    public class PathWithOrientation
+    internal class PathWithOrientation
     {
+        /// <summary>
+        /// Flag to indicate if this path is "Active" or still being extended.
+        /// </summary>
+        internal bool EndReached;
+
         /// <summary>
         /// List of nodes in path.
         /// </summary>
-        private List<DeBruijnNode> nodes;
+        internal List<DeBruijnNode> Nodes;
 
         /// <summary>
         /// Initializes a new instance of the PathWithOrientation class.
@@ -21,7 +26,7 @@ namespace Bio.Algorithms.Assembly.Padena
         /// <param name="node1">First node to add.</param>
         /// <param name="node2">Second node to add.</param>
         /// <param name="orientation">Path orientation.</param>
-        public PathWithOrientation(DeBruijnNode node1, DeBruijnNode node2, bool orientation)
+        internal PathWithOrientation(DeBruijnNode node1, DeBruijnNode node2, bool orientation)
         {
             if (node1 == null)
             {
@@ -33,38 +38,15 @@ namespace Bio.Algorithms.Assembly.Padena
                 throw new ArgumentNullException("node2");
             }
 
-            this.nodes = new List<DeBruijnNode> { node1, node2 };
-            this.IsSameOrientation = orientation;
+            this.Nodes = new List<DeBruijnNode> { node1, node2 };
+            this.GrabNextNodesOnLeft = orientation;
+            this.EndReached = false;
         }
 
         /// <summary>
-        /// Initializes a new instance of the PathWithOrientation class.
-        /// Copies the input path info to a new one.
+        /// Indicates if at the end of the path, the next nodes should come from the
+        /// left or right extensions
         /// </summary>
-        /// <param name="other">Path info to copy.</param>
-        public PathWithOrientation(PathWithOrientation other)
-        {
-            if (other == null)
-            {
-                throw new ArgumentNullException("other");
-            }
-
-            this.nodes = new List<DeBruijnNode>(other.Nodes);
-            this.IsSameOrientation = other.IsSameOrientation;
-        }
-
-        /// <summary>
-        /// Gets the list of nodes in path.
-        /// </summary>
-        public IList<DeBruijnNode> Nodes
-        {
-            get { return this.nodes; }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether path orientation is same or opposite
-        /// with respect to the start node of the path.
-        /// </summary>
-        public bool IsSameOrientation { get; set; }
+        internal bool GrabNextNodesOnLeft;
     }
 }

--- a/src/Source/Tests/Bio.Tests/Algorithms/Assembly/ParallelDenovoTests.cs
+++ b/src/Source/Tests/Bio.Tests/Algorithms/Assembly/ParallelDenovoTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Bio.Algorithms.Alignment;
+using Bio.Algorithms.Assembly;
+using Bio.Algorithms.Assembly.Padena;
+using Bio.Extensions;
+using Bio.SimilarityMatrices;
+using Bio.TestAutomation.Util;
+using Bio.Util.Logging;
+
+using NUnit.Framework;
+
+namespace Bio.Tests.Algorithms.Assembly
+{
+    /// <summary>
+    ///     Assembly Bvt Test case implementation.
+    /// </summary>
+    [TestFixture]
+    public class PadenaTests
+    {
+        
+        [Test]
+        [Category("Padena")]
+        public void ValidateIndelsRemoved()
+        {
+            var seq1 = "ACGTACCCGATAGACACGATACGACAACCCTTTCACGAATCGATACGCAGTACAGATA".Select (x => (byte)x).ToArray ();
+            var seq2 = "ACGTACCCGATAGACACGATACGACAACCCT-TCACGAATCGATACGCAGTACAGATA".Where(z=> z != '-').Select (x => (byte)x).ToArray ();
+            List<Sequence> data = new List<Sequence> (1000);
+            var s1 = new Sequence (DnaAlphabet.Instance, seq1, false);
+            var s2 = new Sequence (DnaAlphabet.Instance, seq2, false);
+            foreach (var i in Enumerable.Range(0, 600)) {
+                data.Add (s1);
+            }
+            foreach (var i in Enumerable.Range(0, 400)) {
+                data.Add (s2);
+            }
+            ParallelDeNovoAssembler asm = new ParallelDeNovoAssembler ();
+            asm.KmerLength = 17;
+            asm.RedundantPathLengthThreshold = 50;
+            asm.ErosionThreshold = 0;
+            asm.DanglingLinksThreshold = 0;
+            var contigs = asm.Assemble (data).AssembledSequences.ToList();
+            Assert.AreEqual (1, contigs.Count);
+            var found_seq = (contigs.First ().GetReverseComplementedSequence() as Sequence).ConvertToString ();
+            Assert.AreEqual (s1.ConvertToString (), found_seq);
+
+        }
+
+       
+    }
+}

--- a/src/Source/Tests/Bio.Tests/Bio.Tests.Core.csproj
+++ b/src/Source/Tests/Bio.Tests/Bio.Tests.Core.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Algorithms\Padena\PadenaP1TestCases.cs" />
     <Compile Include="PacBio\ParserTests.cs" />
     <Compile Include="Variant\VariantCallTests.cs" />
+    <Compile Include="Algorithms\Assembly\ParallelDenovoTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\TestData\Testcases.xml">


### PR DESCRIPTION
Before the redundant path purger could only remove SNPs, this allows
it to call paths like A -> B -> F / A->C->D->E->F as redundant,
simplifying the graph
quite a bit.

Changes include:

* Make PathWithOrientation class to be internal to the assembly
* Remove redundant null check on pass graph
* Allow paths to converge if they have different lengths but wind up at
same end node
* Verified that the paths not only end on the same node, but also
approach it from the same direction

The checking for loops needs to be much faster than it is.